### PR TITLE
Enable serving to a store's live theme and add checks to fail early

### DIFF
--- a/packages/nx-shopify/src/executors/serve/local-assets-server/shopify-sync/shopify-sync-client.ts
+++ b/packages/nx-shopify/src/executors/serve/local-assets-server/shopify-sync/shopify-sync-client.ts
@@ -27,7 +27,11 @@ export class ShopifySyncClient {
     this.filesPendingDeploy = [];
   }
 
-  async syncChangedFiles(changedFiles: string[], stats: WebpackStats) {
+  async syncChangedFiles(
+    changedFiles: string[],
+    stats: WebpackStats,
+    themekitFlags: ThemeKitFlags
+  ) {
     if (this.isDeploymentInProgress) {
       this.filesPendingDeploy = [
         ...new Set([...this.filesPendingDeploy, ...changedFiles]),
@@ -50,7 +54,7 @@ export class ShopifySyncClient {
         outputOptions: { path: outputPath },
       } = stats.compilation;
 
-      await this.deployPendingFiles(outputPath);
+      await this.deployPendingFiles(outputPath, themekitFlags);
       this.skipNextSync = false;
       this.hooks.syncDone.call(changedFiles, stats);
     }
@@ -60,8 +64,12 @@ export class ShopifySyncClient {
     this.skipNextSync = false;
   }
 
-  async deployPendingFiles(compiledOutputPath: string) {
+  async deployPendingFiles(
+    compiledOutputPath: string,
+    themekitFlags: ThemeKitFlags
+  ) {
     const flags: ThemeKitFlags = {
+      ...themekitFlags,
       files: this.filesPendingDeploy,
     };
 

--- a/packages/nx-shopify/src/utils/shopify/index.ts
+++ b/packages/nx-shopify/src/utils/shopify/index.ts
@@ -1,0 +1,2 @@
+export * from './shopify-api-models';
+export * from './shopify-api-utils';

--- a/packages/nx-shopify/src/utils/shopify/shopify-api-models.ts
+++ b/packages/nx-shopify/src/utils/shopify/shopify-api-models.ts
@@ -1,0 +1,16 @@
+export interface ShopifyThemeDTO {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  role: string;
+  theme_store_id: string;
+  previewable: boolean;
+  processing: boolean;
+  admin_graphql_api_id: string;
+}
+
+export interface ShopifyThemesResponse {
+  themes: ShopifyThemeDTO[];
+  errors?: string;
+}

--- a/packages/nx-shopify/src/utils/shopify/shopify-api-utils.ts
+++ b/packages/nx-shopify/src/utils/shopify/shopify-api-utils.ts
@@ -1,0 +1,83 @@
+import * as https from 'https';
+import { ShopifyThemesResponse } from './shopify-api-models';
+
+/**
+ * Fetch the live theme ID from Shopify
+ *
+ * @param themekitEnvConfig String  The themekit environment to get the live theme ID from
+ * @return                  Promise Reason for abort or the live theme ID
+ */
+export function getLiveThemeId(
+  storeHost: string,
+  password: string
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    https.get(
+      {
+        hostname: storeHost,
+        path: '/admin/themes.json',
+        auth: `:${password}`,
+        agent: false,
+        headers: {
+          'X-Shopify-Access-Token': password,
+        },
+      },
+      (res) => {
+        let rawResponseBody = '';
+
+        res.on('data', (chunk) => (rawResponseBody += chunk));
+
+        res.on('end', () => {
+          const responseBody: ShopifyThemesResponse = JSON.parse(
+            rawResponseBody
+          );
+
+          if (responseBody.errors) {
+            reject(
+              new Error(
+                `API request to fetch main theme ID failed: \n${JSON.stringify(
+                  responseBody.errors,
+                  null,
+                  '\t'
+                )}`
+              )
+            );
+            return;
+          }
+
+          if (!Array.isArray(responseBody.themes)) {
+            reject(
+              new Error(
+                `Shopify response for /admin/themes.json is not an array. ${JSON.stringify(
+                  responseBody,
+                  null,
+                  '\t'
+                )}`
+              )
+            );
+            return;
+          }
+
+          const liveTheme = responseBody.themes.find(
+            (theme) => theme.role === 'main'
+          );
+
+          if (!liveTheme) {
+            reject(
+              new Error(
+                `No main theme in response. ${JSON.stringify(
+                  responseBody.themes,
+                  null,
+                  '\t'
+                )}`
+              )
+            );
+            return;
+          }
+
+          resolve(liveTheme.id);
+        });
+      }
+    );
+  });
+}

--- a/packages/nx-shopify/src/utils/themekit/index.ts
+++ b/packages/nx-shopify/src/utils/themekit/index.ts
@@ -1,2 +1,3 @@
 export * from './themekit-cli-utils';
 export * from './themekit-config-utils';
+export * from './themekit-config-utils';

--- a/packages/nx-shopify/src/utils/themekit/themekit-validation-utils.ts
+++ b/packages/nx-shopify/src/utils/themekit/themekit-validation-utils.ts
@@ -1,0 +1,10 @@
+import { getLiveThemeId } from '../shopify';
+import { ThemekitEnvironmentConfig } from './themekit-config-utils';
+
+export async function isLiveTheme(
+  themekitEnvConfig: ThemekitEnvironmentConfig
+): Promise<boolean> {
+  const { store, password, themeId } = themekitEnvConfig;
+  const liveThemeId = await getLiveThemeId(store, password);
+  return themeId === liveThemeId.toString();
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

<!-- This is the behavior we have today -->
When serving to a store live's theme the `--allowLive` option does not works and the command fails when it tries to deploy changed files to Shopify.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->
When trying to serve to a store's live theme, the `--allowLive` option should make possible to deploy the changed files to Shopify.

If a theme is trying to be served to a store's live theme without passing the `--allowLive` option, the command should fail explaning the error.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32
